### PR TITLE
Fix failing CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 python: 3.7
 
 install:
-  - pip install -e ".[test]"
+  - pip install -e ".[test]" --upgrade --upgrade-strategy eager
 
 script: pytest tests
 


### PR DESCRIPTION
The [latest CI build](https://travis-ci.com/github/cmla/plyflatten/jobs/349196471) fails.

This is due to:
- `pytest 4.3.1` already being installed in Travis' python environment
- `pytest-cov 2.1.0` dropping support for older `pytest` versions and now requiring `pytest>=4.6.0` [source](https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst#2100-2020-06-12)

I went with the solution already used in `s2p` which is to ask `pip` to upgrade packages eagerly.